### PR TITLE
inputCount change

### DIFF
--- a/contracts/Libraries/Validate.sol
+++ b/contracts/Libraries/Validate.sol
@@ -14,16 +14,19 @@ library Validate {
         bytes memory sig2 = ByteUtils.slice(sigs, 65, 65);
         bytes memory confSig1 = ByteUtils.slice(sigs, 130, 65);
         bytes32 confirmationHash = keccak256(txHash, sig1, sig2, rootHash);
+        
         if (blknum1 == 0 && blknum2 == 0) {
             return msg.sender == ECRecovery.recover(confirmationHash, confSig1);
         }
-        if (blknum2 == 0) {
-            return ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
-        } else {
+        bool check1 = true;
+        bool check2 = true;
+        if (blknum1 > 0) {
+            check1 = ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
+        } 
+        if (blknum2 > 0) {
             bytes memory confSig2 = ByteUtils.slice(sigs, 195, 65);
-            bool check1 = ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
-            bool check2 = ECRecovery.recover(txHash, sig2) == ECRecovery.recover(confirmationHash, confSig2);
-            return check1 && check2;
+            check2 = ECRecovery.recover(txHash, sig2) == ECRecovery.recover(confirmationHash, confSig2);
         }
+        return check1 && check2;
     }
 }

--- a/contracts/Libraries/Validate.sol
+++ b/contracts/Libraries/Validate.sol
@@ -4,7 +4,7 @@ import './ECRecovery.sol';
 
 
 library Validate {
-    function checkSigs(bytes32 txHash, bytes32 rootHash, uint256 inputCount, bytes sigs)
+    function checkSigs(bytes32 txHash, bytes32 rootHash,  uint256 blknum1, uint256 blknum2, bytes sigs)
         internal
         view
         returns (bool)
@@ -14,10 +14,10 @@ library Validate {
         bytes memory sig2 = ByteUtils.slice(sigs, 65, 65);
         bytes memory confSig1 = ByteUtils.slice(sigs, 130, 65);
         bytes32 confirmationHash = keccak256(txHash, sig1, sig2, rootHash);
-        if (inputCount == 0) {
+        if (blknum1 == 0 && blknum2 == 0) {
             return msg.sender == ECRecovery.recover(confirmationHash, confSig1);
         }
-        if (inputCount < 1000000) {
+        if (blknum2 == 0) {
             return ECRecovery.recover(txHash, sig1) == ECRecovery.recover(confirmationHash, confSig1);
         } else {
             bytes memory confSig2 = ByteUtils.slice(sigs, 195, 65);

--- a/contracts/RootChain/RootChain.sol
+++ b/contracts/RootChain/RootChain.sol
@@ -158,8 +158,7 @@ contract RootChain {
         require(msg.value >= txList[7 + 2 * txPos[2]].toUint() * minExitBond / 100);
         bytes32 txHash = keccak256(txBytes);
         bytes32 merkleHash = keccak256(txHash, ByteUtils.slice(sigs, 0, 130));
-        uint256 inputCount = txList[3].toUint() * 1000000 + txList[0].toUint();
-        require(Validate.checkSigs(txHash, childChain[txPos[0]].root, inputCount, sigs));
+        require(Validate.checkSigs(txHash, childChain[txPos[0]].root, txList[0].toUint(), txList[3].toUint(), sigs));
         require(merkleHash.checkMembership(txPos[1], childChain[txPos[0]].root, proof));
         uint256 priority = 1000000000 + txPos[1] * 10000 + txPos[2];
         uint256 exitId = txPos[0].mul(priority);


### PR DESCRIPTION
Fixes both the inputCount bug of Input 1 block number getting too large and fixes the issue where input 1 can be zeroed out and input 2 contain a valid input. inputCount is not needed as the block number's are passed directly into the checkSigs. 