### PR TITLE
Added Running section in README and RootChain migration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See our [documentation](https://github.com/FourthState/plasma-mvp-rootchain/blob
 
 
 ### Running
-The first migration file `1_initial_migration` deploys the `PriorityQueue` library, while the second one `2_deploy_rootchain` actually deploys the `RootChain` contract. Ethereum requires libraries to already be deployed prior to be used by other contracts.
+The first migration file `1_initial_migration` deploys the `PriorityQueue` library and links it to the `RootChain` contract, while the second one `2_deploy_rootchain` finally makes the deployment. Ethereum requires libraries to already be deployed prior to be used by other contracts.
 
 If you encounter problems, make sure your local test rpc (e.g. [ganache](https://github.com/trufflesuite/ganache-core)) has the same network id as the contract's json from the `build` folder.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ See our [documentation](https://github.com/FourthState/plasma-mvp-rootchain/blob
 5. ``ganache-cli`` // run as a background process
 5. ``npm test``
 
+
+### Running
+The first migration file `1_initial_migration` deploys the `PriorityQueue` library, while the second one `2_deploy_rootchain` actually deploys the `RootChain` contract. Ethereum requires libraries to already be deployed prior to be used by other contracts.
+
+If you encounter problems, make sure your local test rpc (e.g. [ganache](https://github.com/trufflesuite/ganache-core)) has the same network id as the contract's json from the `build` folder.
+
 ### Contributing
 
 See our [contribution guidelines](https://github.com/FourthState/plasma-mvp-rootchain/blob/master/CONTRIBUTING.md). Join our [Discord Server](https://discord.gg/yxZ29kR).

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17;
+pragma solidity ^0.4.24;
 
 contract Migrations {
   address public owner;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.17; 
+pragma solidity ^0.4.17;
 
 contract Migrations {
   address public owner;
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 

--- a/docs/rootchainFunctions.md
+++ b/docs/rootchainFunctions.md
@@ -28,7 +28,7 @@ struct depositStruct {
 ```solidity
 function startTransactionExit(uint256[3] txPos, bytes txBytes, bytes proof, bytes sigs, bytes confirmSignatures)
 ```
-`txPos` follows the convention - `[blockNumber, transcationIndex, outputIndex]`
+`txPos` follows the convention - `[blockNumber, transactionIndex, outputIndex]`
 
 Exit procedure for exiting a utxo on the child chain(not deposits). The `txPos` locates the transaction on the child chain. The leaf, hash(hash(`txBytes`), `sigs`) is checked against the block header using the `proof`.
 The `confirmSignatures` represent the acknowledgement of the inclusion by both inputs. If only one input was used to create this transactions, only one confirm signature should be passed in for the corresponding
@@ -44,7 +44,7 @@ A valid exit satisfies the following properties:
 ```solidity
 function startDepositExit(uint256 nonce)
 ```
-Exit procdure for deposits that have not been spent. Deposits are purely identified by their `nonce`. The caller's address must match the owner of the deposit.
+Exit procedure for deposits that have not been spent. Deposits are purely identified by their `nonce`. The caller's address must match the owner of the deposit.
 A valid exit must satisfy the same constraints listed above for normal utxo exits except confirm signatures. Deposits exits are also collected into their own seperate queue from normal transcations.
 This is because of the differing priority calculation. The priority of a deposit is purely it's nonce while the priority of a utxo is calculated from it's location in the child chain.
 

--- a/migrations/2_deploy_rootchain.js
+++ b/migrations/2_deploy_rootchain.js
@@ -1,0 +1,5 @@
+let RootChain = artifacts.require("RootChain");
+
+module.exports = function(deployer, network, accounts) {
+	deployer.deploy(RootChain, {from: accounts[0]});
+};


### PR DESCRIPTION
Full list of changes:

* Added `2_deploy_rootchain.js` file, as the first migration file wasn't actually deploying the `RootChain` contract and it wasn't available in `truffle console`
* Added a Running section which explains the rationale for the point above
* Rewritten `Migrations`'s contructor to get rid of the warning, as per Solidity ^0.4.22
* Fixed some minor spelling errors in `docs/rootchainFunctions.md`
