### PR TITLE
variable submitBlock root length. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js: "node"
 
 before_script:
-  - npm install -g truffle@4.1.11 ganache-cli@6.1.0
+  - npm install -g truffle@4.1.14 ganache-cli@6.1.8
   - npm install
 
 script: 

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -90,8 +90,8 @@ contract RootChain is Ownable {
         public
         onlyOwner
     {
-        // ensure finality on previous blocks before submitting another
         require(block.number >= lastParentBlock.add(6), "presumed finality required");
+        require(blocks.length != 0 && blocks.length % 32 == 0, "block roots must be of size 32 bytes");
 
         uint memPtr;
         assembly  {

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -85,18 +85,31 @@ contract RootChain is Ownable {
         minExitBond = 10000;
     }
 
-    // @param root 32 byte merkleRoot of ChildChain block
-    function submitBlock(bytes32 root)
+    // @param blocks 32 byte merkle roots
+    function submitBlock(bytes blocks)
         public
         onlyOwner
     {
         // ensure finality on previous blocks before submitting another
         require(block.number >= lastParentBlock.add(6), "presumed finality required");
 
-        childChain[currentChildBlock] = childBlock(root, block.timestamp);
-        emit BlockSubmitted(root, currentChildBlock);
+        uint memPtr;
+        assembly  {
+            memPtr := add(blocks, 0x20)
+        }
 
-        currentChildBlock = currentChildBlock.add(1);
+        bytes32 root;
+        for (uint i = 0; i < blocks.length; i += 32) {
+            assembly {
+                root := mload(add(memPtr, i))
+            }
+
+            childChain[currentChildBlock] = childBlock(root, block.timestamp);
+            emit BlockSubmitted(root, currentChildBlock);
+
+            currentChildBlock = currentChildBlock.add(1);
+        }
+
         lastParentBlock = block.number;
     }
 

--- a/docs/rootchainFunctions.md
+++ b/docs/rootchainFunctions.md
@@ -2,7 +2,7 @@
 ```solidity
 function submitBlock(bytes32 root)
 ```
-The validator submits the block header, `root` of each child chain block.  
+The validator submits the block header, `root` of each child chain block. More than one block can be submitted per call by appending the roots to one another.  
 
 <br >
 

--- a/test/rootchain/blockSubmissions.js
+++ b/test/rootchain/blockSubmissions.js
@@ -18,22 +18,21 @@ contract('[RootChain] Block Submissions', async (accounts) => {
 
         // waiting at least 5 root chain blocks before submitting a block
         mineNBlocks(5);
+        let root = web3.sha3('1234');
+        let tx = await rootchain.submitBlock(root, {from: authority});
 
-        let blockRoot = '2984748479872';
-        let tx = await rootchain.submitBlock(web3.fromAscii(blockRoot), {from: authority});
         // BlockSubmitted event
-        assert.equal(web3.toUtf8(tx.logs[0].args.root), blockRoot, "incorrect block root in BlockSubmitted event");
+        assert.equal(tx.logs[0].args.root, root, "incorrect block root in BlockSubmitted event");
         assert.equal(tx.logs[0].args.blockNumber.toNumber(), blkNum, "incorrect block number in BlockSubmitted event");
 
-        let childBlock = (await rootchain.getChildBlock.call(blkNum));
-        assert.equal(web3.toUtf8(childBlock[0]), blockRoot, 'Child block merkle root does not match submitted merkle root.');
+        assert.equal((await rootchain.getChildBlock.call(blkNum))[0], root, 'Child block merkle root does not match submitted merkle root.');
     });
 
     it("Submit block from someone other than authority", async () => {
         let prev = (await rootchain.currentChildBlock.call()).toNumber();
 
         mineNBlocks(5);
-        let [err] = await catchError(rootchain.submitBlock(web3.fromAscii('578484785954'), {from: accounts[1]}));
+        let [err] = await catchError(rootchain.submitBlock(web3.sha3('578484785954'), {from: accounts[1]}));
         if (!err)
             assert.fail("Submitted blocked without being the authority");
 
@@ -46,15 +45,16 @@ contract('[RootChain] Block Submissions', async (accounts) => {
         let blkNum = (await rootchain.currentChildBlock.call()).toNumber();
 
         mineNBlocks(5);
-        let root = '2984748479872'
-        let tx = await rootchain.submitBlock(web3.fromAscii(root), {from: authority});
+        let root = web3.sha3('12345');
+        let tx = await rootchain.submitBlock(root, {from: authority});
+
         // BlockSubmitted event
-        assert.equal(web3.toUtf8(tx.logs[0].args.root), root, "incorrect block root in BlockSubmitted event");
+        assert.equal(tx.logs[0].args.root, root, "incorrect block root in BlockSubmitted event");
         assert.equal(tx.logs[0].args.blockNumber.toNumber(), blkNum, "incorrect block number in BlockSubmitted event");
 
         // Second submission does not wait and therfore fails.
         mineNBlocks(3);
-        let [err] = await catchError(rootchain.submitBlock(web3.fromAscii('696969696969'), {from: authority}));
+        let [err] = await catchError(rootchain.submitBlock(web3.sha3('696969696969'), {from: authority}));
         if (!err)
             assert.fail("Submitted block without presumed finality");
     });

--- a/test/rootchain/miscellaneous.js
+++ b/test/rootchain/miscellaneous.js
@@ -1,5 +1,8 @@
 let RootChain = artifacts.require("RootChain");
 
+let { catchError, toHex } = require("../utilities.js");
+let { mineNBlocks } = require("./rootchain_helpers.js");
+
 contract('[RootChain] Miscellaneous', async (accounts) => {
 
     let rootchain;
@@ -11,5 +14,21 @@ contract('[RootChain] Miscellaneous', async (accounts) => {
     it("Will not revert finalizeExit with an empty queue", async () => {
         await rootchain.finalizeDepositExits();
         await rootchain.finalizeTransactionExits();
+    });
+
+    it("Can submit more than one merkle root", async () => {
+        let root1 = web3.sha3("root1").slice(2);
+        let root2 = web3.sha3("root2").slice(2);
+        let roots = root1 + root2;
+
+        // rootchain finality check
+        mineNBlocks(6);
+
+        let currentChildBlock = (await rootchain.currentChildBlock.call()).toNumber();
+        rootchain.submitBlock(toHex(roots), {from: authority});
+
+        assert.equal((await rootchain.currentChildBlock.call()).toNumber(), currentChildBlock + 2, "blocknum incremented incorrectly");
+        assert.equal((await rootchain.getChildBlock.call(currentChildBlock))[0], toHex(root1), "mismatch in block root");
+        assert.equal((await rootchain.getChildBlock.call(currentChildBlock+1))[0], toHex(root2), "mismatch in block root");
     });
 });


### PR DESCRIPTION
Provide the ability for an operator to submit more than one block header at a time by appending them together.

Also updating truffle/ganache-cli versions in travis