### PR TITLE
[Audit Milestone] Exits

### DIFF
--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -25,14 +25,11 @@ contract RootChain is Ownable {
     event BlockSubmitted(bytes32 root, uint256 blockNumber);
     event Deposit(address depositor, uint256 amount, uint256 depositNonce);
 
-    event ChallengedTransactionExit(uint position, address owner, uint256 amount);
-    event ChallengedDepositExit(uint nonce, address owner, uint256 amount);
-
-    event FinalizedTransactionExit(uint position, address owner, uint256 amount);
-    event FinalizedDepositExit(uint priority, address owner, uint256 amount);
-
-    event StartedTransactionExit(uint position, address owner, uint256 amount, bytes confirmSignatures);
+    event StartedTransactionExit(uint[3] position, address owner, uint256 amount, bytes confirmSignatures);
     event StartedDepositExit(uint nonce, address owner, uint256 amount);
+
+    event ChallengedExit(uint[4] position, address owner, uint256 amount);
+    event FinalizedExit(uint[4] position, address owner, uint256 amount);
 
     /*
      *  Storage
@@ -65,6 +62,7 @@ contract RootChain is Ownable {
         uint256 amount;
         uint256 createdAt;
         address owner;
+        uint256[4] position; // (blkNum, txIndex, outputIndex, depositNonce)
         ExitState state; // default value is `NonExistent`
     }
 
@@ -145,6 +143,7 @@ contract RootChain is Ownable {
             owner: owner,
             amount: amount,
             createdAt: block.timestamp,
+            position: [0,0,0,nonce],
             state: ExitState.Pending
         });
 
@@ -225,10 +224,11 @@ contract RootChain is Ownable {
             owner: txList[12 + 2 * txPos[2]].toAddress(),
             amount: txList[13 + 2 * txPos[2]].toUint(),
             createdAt: block.timestamp,
+            position: [txPos[0], txPos[1], txPos[2], 0],
             state: ExitState.Pending
         });
 
-        emit StartedTransactionExit(position, msg.sender, txList[13 + 2 * txPos[2]].toUint(), confirmSignatures);
+        emit StartedTransactionExit(txPos, msg.sender, txList[13 + 2 * txPos[2]].toUint(), confirmSignatures);
     }
 
     // For any attempted exit of an UTXO, validate that the UTXO's two inputs have not
@@ -287,7 +287,7 @@ contract RootChain is Ownable {
         totalWithdrawBalance = totalWithdrawBalance.add(minExitBond);
 
         depositExits[nonce].state = ExitState.Challenged;
-        emit ChallengedDepositExit(nonce, exit_.owner, exit_.amount);
+        emit ChallengedExit(exit_.position, exit_.owner, exit_.amount);
     }
 
     // @param exitingTxPos     position of the invalid exiting transaction [blkNum, txIndex, outputIndex]
@@ -324,7 +324,7 @@ contract RootChain is Ownable {
 
         // reflect challenged state
         txExits[position].state = ExitState.Challenged;
-        emit ChallengedTransactionExit(position, exit_.owner, exit_.amount);
+        emit ChallengedExit(exit_.position, exit_.owner, exit_.amount);
     }
 
     // When challenging an exiting transcation located at `exitingTxPos`, we must make sure that the challenging
@@ -375,7 +375,7 @@ contract RootChain is Ownable {
         * Conditions:
         *   1. Exits exist
         *   2. Exits must be a week old
-        *   3. Funds must exists for the exit to withdraw
+        *   3. Funds must exist for the exit to withdraw
         */
         uint256 amountToAdd;
         while (queue.currentSize() > 0 &&
@@ -390,14 +390,12 @@ contract RootChain is Ownable {
                 balances[currentExit.owner] = balances[currentExit.owner].add(amountToAdd);
                 totalWithdrawBalance = totalWithdrawBalance.add(amountToAdd);
 
-                if (isDeposits) {
+                if (isDeposits)
                     depositExits[priority].state = ExitState.Finalized;
-                    emit FinalizedDepositExit(priority, currentExit.owner, amountToAdd);
-                } else {
+                else
                     txExits[position].state = ExitState.Finalized;
-                    emit FinalizedTransactionExit(position, currentExit.owner, amountToAdd);
-                }
 
+                emit FinalizedExit(currentExit.position, currentExit.owner, amountToAdd);
                 emit AddedToBalances(currentExit.owner, amountToAdd);
 
                 // move onto the next oldest exit
@@ -458,40 +456,5 @@ contract RootChain is Ownable {
         returns (uint256)
     {
         return balances[_address];
-    }
-
-    function getChildBlock(uint256 blockNumber)
-        public
-        view
-        returns (bytes32, uint256)
-    {
-        return (childChain[blockNumber].root, childChain[blockNumber].createdAt);
-    }
-
-    function getTransactionExit(uint256 position)
-        public
-        view
-        returns (address, uint256, uint256, ExitState)
-    {
-        exit memory exit_ = txExits[position];
-        return (exit_.owner, exit_.amount, exit_.createdAt, exit_.state);
-    }
-
-    function getDepositExit(uint256 priority)
-        public
-        view
-        returns (address, uint256, uint256, ExitState)
-    {
-        exit memory exit_ = depositExits[priority];
-        return (exit_.owner, exit_.amount, exit_.createdAt, exit_.state);
-    }
-
-    function getDeposit(uint256 nonce)
-        public
-        view
-        returns(address, uint256, uint256)
-    {
-        depositStruct memory deposit_ = deposits[nonce];
-        return (deposit_.owner, deposit_.amount, deposit_.createdAt);
     }
 }

--- a/test/rootchain/blockSubmissions.js
+++ b/test/rootchain/blockSubmissions.js
@@ -25,7 +25,7 @@ contract('[RootChain] Block Submissions', async (accounts) => {
         assert.equal(tx.logs[0].args.root, root, "incorrect block root in BlockSubmitted event");
         assert.equal(tx.logs[0].args.blockNumber.toNumber(), blkNum, "incorrect block number in BlockSubmitted event");
 
-        assert.equal((await rootchain.getChildBlock.call(blkNum))[0], root, 'Child block merkle root does not match submitted merkle root.');
+        assert.equal((await rootchain.childChain.call(blkNum))[0], root, 'Child block merkle root does not match submitted merkle root.');
     });
 
     it("Submit block from someone other than authority", async () => {

--- a/test/rootchain/deposits.js
+++ b/test/rootchain/deposits.js
@@ -35,7 +35,7 @@ contract('[RootChain] Deposits', async (accounts) => {
         assert.equal(tx.logs[0].args.depositNonce, nonce, "incorrect deposit nonce");
 
         // check rootchain deposit mapping
-        let deposit = await rootchain.getDeposit.call(nonce);
+        let deposit = await rootchain.deposits.call(nonce);
         assert.equal(deposit[0], accounts[2], "incorrect deposit owner");
         assert.equal(deposit[1], 100, "incorrect deposit amount");
     });
@@ -107,7 +107,7 @@ contract('[RootChain] Deposits', async (accounts) => {
         let balance = (await rootchain.balanceOf.call(accounts[2])).toNumber();
         assert.equal(balance, 100 + minExitBond, "deposit exit not finalized after a week");
 
-        let exit = await rootchain.getDepositExit.call(nonce);
+        let exit = await rootchain.depositExits.call(nonce);
         assert.equal(exit[3], 3, "exit's state not set to finalized");
     });
 
@@ -178,7 +178,7 @@ contract('[RootChain] Deposits', async (accounts) => {
         let balance = (await rootchain.balanceOf.call(accounts[3])).toNumber();
         assert.equal(balance, minExitBond, "challenger not awarded exit bond");
 
-        let exit = await rootchain.getDepositExit.call(nonce);
+        let exit = await rootchain.depositExits.call(nonce);
         assert.equal(exit[3], 2, "exit state not changed to challenged");
 
         // Cannot challenge twice

--- a/test/rootchain/miscellaneous.js
+++ b/test/rootchain/miscellaneous.js
@@ -25,10 +25,10 @@ contract('[RootChain] Miscellaneous', async (accounts) => {
         mineNBlocks(6);
 
         let currentChildBlock = (await rootchain.currentChildBlock.call()).toNumber();
-        rootchain.submitBlock(toHex(roots), {from: authority});
+        await rootchain.submitBlock(toHex(roots), {from: authority});
 
         assert.equal((await rootchain.currentChildBlock.call()).toNumber(), currentChildBlock + 2, "blocknum incremented incorrectly");
-        assert.equal((await rootchain.getChildBlock.call(currentChildBlock))[0], toHex(root1), "mismatch in block root");
-        assert.equal((await rootchain.getChildBlock.call(currentChildBlock+1))[0], toHex(root2), "mismatch in block root");
+        assert.equal((await rootchain.childChain.call(currentChildBlock))[0], toHex(root1), "mismatch in block root");
+        assert.equal((await rootchain.childChain.call(currentChildBlock+1))[0], toHex(root2), "mismatch in block root");
     });
 });

--- a/test/rootchain/transactions.js
+++ b/test/rootchain/transactions.js
@@ -70,8 +70,7 @@ contract('[RootChain] Transactions', async (accounts) => {
             toHex(txBytes), toHex(proof), toHex(confirmSignatures),
             {from: accounts[1], value: minExitBond});
 
-        let position = 1000000*txPos[0];
-        assert.equal(tx.logs[0].args.position.toNumber(), position, "StartedTransactionExit event emits incorrect priority");
+        assert.equal(tx.logs[0].args.position.toString(), txPos.toString(), "StartedTransactionExit event emits incorrect priority");
         assert.equal(tx.logs[0].args.owner, accounts[1], "StartedTransactionExit event emits incorrect owner");
         assert.equal(tx.logs[0].args.amount.toNumber(), amount, "StartedTransactionExit event emits incorrect amount");
         assert.equal(tx.logs[0].args.confirmSignatures, toHex(confirmSignatures), "StartedTransactionExit event does not emit confirm signatures");
@@ -90,7 +89,7 @@ contract('[RootChain] Transactions', async (accounts) => {
         assert.equal(balance, amount + minExitBond);
 
         let position = 1000000*txPos[0];
-        let exit = await rootchain.getTransactionExit.call(position);
+        let exit = await rootchain.txExits.call(position);
         assert.equal(exit[3].toNumber(), 3, "exit's state not set to finalized");
     });
 
@@ -358,8 +357,8 @@ contract('[RootChain] Transactions', async (accounts) => {
 
         // Check to make sure challenge period has not ended
         let position = 1000000 * blockNum2 + 1;
-        let currExit = await rootchain.getTransactionExit.call(position);
-        assert.ok((currExit[2].add(604800)) > (await web3.eth.getBlock(await web3.eth.blockNumber)).timestamp);
+        let currExit = await rootchain.txExits.call(position);
+        assert.ok((currExit[2] + 604800) > (await web3.eth.getBlock(await web3.eth.blockNumber)).timestamp);
 
         // start exit for accounts[1], oldest utxo avaliable
         await rootchain.startTransactionExit([blockNum1, 0, 0],
@@ -370,34 +369,34 @@ contract('[RootChain] Transactions', async (accounts) => {
 
         // finalize exits should finalize accounts[2] then accounts[1]
         let finalizedExits = await rootchain.finalizeTransactionExits({from: authority});
-        let finalizedExit = await rootchain.getTransactionExit.call(position);
-        assert.equal(finalizedExits.logs[0].args.position, position, "Incorrect position for finalized tx");
+        let finalizedExit = await rootchain.txExits.call(position);
+        assert.equal(finalizedExits.logs[0].args.position.toString(), [blockNum2, 0, 1, 0].toString(), "Incorrect position for finalized tx");
         assert.equal(finalizedExits.logs[0].args.owner, accounts[2], "Incorrect finalized exit owner");
         assert.equal(finalizedExits.logs[0].args.amount.toNumber(), 25 + minExitBond, "Incorrect finalized exit amount.");
         assert.equal(finalizedExit[3].toNumber(), 3, "Incorrect finalized exit state.");
 
         // Check other exits
         position = 1000000 * blockNum2;
-        finalizedExit = await rootchain.getTransactionExit.call(position);
-        assert.equal(finalizedExits.logs[2].args.position, position, "Incorrect position for finalized tx");
+        finalizedExit = await rootchain.txExits.call(position);
+        assert.equal(finalizedExits.logs[2].args.position.toString(), [blockNum2, 0, 0, 0].toString(), "Incorrect position for finalized tx");
         assert.equal(finalizedExits.logs[2].args.owner, accounts[1], "Incorrect finalized exit owner");
         assert.equal(finalizedExits.logs[2].args.amount.toNumber(), 25 + minExitBond, "Incorrect finalized exit amount.");
         assert.equal(finalizedExit[3].toNumber(), 3, "Incorrect finalized exit state.");
 
         // Last exit should still be pending
         position = 1000000 * blockNum1;
-        let pendingExit = await rootchain.getTransactionExit.call(position);
-        assert.equal(pendingExit[0], accounts[1], "Incorrect pending exit owner");
-        assert.equal(pendingExit[1], 50, "Incorrect pending exit amount");
+        let pendingExit = await rootchain.txExits.call(position);
+        assert.equal(pendingExit[2], accounts[1], "Incorrect pending exit owner");
+        assert.equal(pendingExit[0], 50, "Incorrect pending exit amount");
         assert.equal(pendingExit[3].toNumber(), 1, "Incorrect pending exit state.");
 
         // Fast Forward rest of challenge period
         fastForward(one_week);
         await rootchain.finalizeTransactionExits({from: authority});
         // Check that last exit was processed
-        finalizedExit = await rootchain.getTransactionExit.call(position);
-        assert.equal(finalizedExit[0], accounts[1], "Incorrect finalized exit owner");
-        assert.equal(finalizedExit[1], 50, "Incorrect finalized exit amount");
+        finalizedExit = await rootchain.txExits.call(position);
+        assert.equal(finalizedExit[2], accounts[1], "Incorrect finalized exit owner");
+        assert.equal(finalizedExit[0], 50, "Incorrect finalized exit amount");
         assert.equal(finalizedExit[3].toNumber(), 3, "Incorrect finalized exit state.");
     });
 });


### PR DESCRIPTION
1.) Added transaction position to the exit structure and appropriate events
- Position = [blockNum, txIndex, outputIndex, depositNonce]

2.) Removed getter functions from contract. Public variables can be queried directly

3.) Tests reflect the above
