### PR TITLE
[Audit milestone] Fee withdrawal for validators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ The root contract of a Plasma child chain represents an intermediary who can res
 A transaction is encoded in the following form:
 
 ```
-[ 
-  [Blknum1, TxIndex1, Oindex1, DepositNonce1, Amount1, ConfirmSig1,
+[
+  [Blknum1, TxIndex1, Oindex1, DepositNonce1, Owner1, Input1ConfirmSig,
 
-  Blknum2, TxIndex2, Oindex2, DepositNonce2, Amount2, ConfirmSig2,
+   Blknum2, TxIndex2, Oindex2, DepositNonce2, Owner2, Input2ConfirmSig,
 
-  NewOwner, Denom1, NewOwner, Denom2, Fee],
+   NewOwner, Denom1, NewOwner, Denom2, Fee],
 
   [Signature1, Signature2]
 ]

--- a/contracts/libraries/Validator_Test.sol
+++ b/contracts/libraries/Validator_Test.sol
@@ -12,6 +12,7 @@ contract Validator_Test {
 
   function checkMembership(bytes32 leaf, uint256 index, bytes32 rootHash, bytes proof, uint256 total)
       public
+      pure
       returns (bool)
   {
       return leaf.checkMembership(index, rootHash, proof, total);

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -272,8 +272,7 @@ contract RootChain is Ownable {
         onlyOwner
     {
         // specified blockNumber must exist in child chain
-        bytes32 empty;
-        require(childChain[blockNumber].root != empty, "specified block does not exist in child chain.");
+        require(childChain[blockNumber].root != bytes32(0), "specified block does not exist in child chain.");
 
         require(msg.value >= minExitBond, "insufficient exit bond");
         if (msg.value > minExitBond) {

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -109,10 +109,8 @@ contract RootChain is Ownable {
                 root := mload(add(memPtr, mul(i, 32)))
             }
 
-            childChain[blockNum] = childBlock(root, txnsPerBlock[i], feesPerBlock[i], block.timestamp);
-            emit BlockSubmitted(root, blockNum, txnsPerBlock[i], feesPerBlock[i]);
-
-            blockNum = blockNum.add(1);
+            childChain[blockNum + i] = childBlock(root, txnsPerBlock[i], feesPerBlock[i], block.timestamp);
+            emit BlockSubmitted(root, blockNum + i, txnsPerBlock[i], feesPerBlock[i]);
         }
 
         lastCommittedBlock = lastCommittedBlock.add(txnsPerBlock.length);
@@ -158,9 +156,9 @@ contract RootChain is Ownable {
     }
 
     // Transaction encoding:
-    // [[Blknum0, TxIndex0, Oindex0, depositNonce0, Amount0, ConfirmSig0
-    //  Blknum1, TxIndex1, Oindex1, depositNonce1, Amount1, ConfirmSig1
-    //  NewOwner0, Denom0, NewOwner1, Denom1, Fee],
+    // [[Blknum1, TxIndex1, Oindex1, DepositNonce1, Owner1, Input1ConfirmSig,
+    //   Blknum2, TxIndex2, Oindex2, DepositNonce2, Owner2, Input2ConfirmSig,
+    //   NewOwner, Denom1, NewOwner, Denom2, Fee],
     //  [Signature1, Signature2]]
     //
     // @param txBytes rlp encoded transaction
@@ -436,7 +434,7 @@ contract RootChain is Ownable {
         while (queue.currentSize() > 0 &&
                (block.timestamp - currentExit.createdAt) > 1 weeks &&
                currentExit.amount.add(minExitBond) <= address(this).balance - totalWithdrawBalance &&
-               msg.gas > 80000) {
+               gasleft() > 80000) {
 
             // skip currentExit if it is not in 'started/pending' state.
             if (currentExit.state != ExitState.Pending) {

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -100,8 +100,11 @@ contract RootChain is Ownable {
             memPtr := add(blocks, 0x20)
         }
 
+        uint maxNumTxPerBlock = 2**16 - 1;
         bytes32 root;
         for (uint i = 0; i < txnsPerBlock.length; i++) {
+            require(txnsPerBlock[i] <= maxNumTxPerBlock, "number of transactions per block exceeds limit");
+
             assembly {
                 root := mload(add(memPtr, mul(i, 32)))
             }

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -82,10 +82,10 @@ contract RootChain is Ownable {
         minExitBond = 10000;
     }
 
-    // @param blocks 32 byte merkle roots appended in ascending order
+    // @param blocks       32 byte merkle roots appended in ascending order
     // @param txnsPerBlock number of transactions per block
     // @param feesPerBlock amount of fees the validator has collected per block
-    // @param blockNum the block number of the first header
+    // @param blockNum     the block number of the first header
     function submitBlock(bytes blocks, uint256[] txnsPerBlock, uint256[] feesPerBlock, uint256 blockNum)
         public
         onlyOwner
@@ -251,9 +251,6 @@ contract RootChain is Ownable {
                 uint256 inputIndex = txList[6*i + 1].toUint();
                 uint256 outputIndex = txList[6*i + 2].toUint();
                 uint256 position = blockIndexFactor*blkNum + txIndexFactor*inputIndex + outputIndex;
-
-                require(outputIndex <= 1 && inputIndex < 2 ** 16, "invalid transaction positions");
-
                 state = txExits[position].state;
             } else
                 state = depositExits[depositNonce_].state;
@@ -269,7 +266,7 @@ contract RootChain is Ownable {
     // for that particular block. The fee exit is added to exit queue with the lowest priority for that block.
     // In case of the fee UTXO already spent, anyone can challenge the fee exit by providing
     // the spend of the fee UTXO.
-    // @param blockNumber      the block for which the validator wants to exit fees
+    // @param blockNumber the block for which the validator wants to exit fees
     function startFeeExit(uint256 blockNumber)
         public
         payable

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -253,6 +253,9 @@ contract RootChain is Ownable {
                 uint256 inputIndex = txList[6*i + 1].toUint();
                 uint256 outputIndex = txList[6*i + 2].toUint();
                 uint256 position = blockIndexFactor*blkNum + txIndexFactor*inputIndex + outputIndex;
+
+                require(outputIndex <= 1 && inputIndex < 2 ** 16, "invalid transaction positions");
+
                 state = txExits[position].state;
             } else
                 state = depositExits[depositNonce_].state;

--- a/docs/rootchainFunctions.md
+++ b/docs/rootchainFunctions.md
@@ -13,9 +13,9 @@ RLP_ENCODE ([
 ])
 ```
 ```solidity
-function submitBlock(bytes32 blocks, uint256[] txnsPerBlock, uint256 blockNum)
+function submitBlock(bytes32 blocks, uint256[] txnsPerBlock, uint256[] feesPerBlock, uint256 blockNum)
 ```
-The validator submits appended block headers in ascending order. Each block can be of variable block size(capped at 2^16 txns per block). The total number of transactions per block must be passed in through `txnsPerBlock`.
+The validator submits appended block headers in ascending order. Each block can be of variable block size(capped at 2^16 txns per block). The total number of transactions per block must be passed in through `txnsPerBlock`. The amount of transaction fees collected by the validator per block must be passed in through `feesPerBlock`.
 `blockNum` must be the intended block number of the first header in this call. Ordering is enforced on each call. `blockNum == lastCommittedBlock + 1`.
 
 <br >
@@ -65,11 +65,11 @@ This is because of the differing priority calculation. The priority of a deposit
 <br />
 
 ```solidity
-function startFeeExit(uint256 blockNumber, uint256 feeAmount)
+function startFeeExit(uint256 blockNumber)
 ```
 The validator of any block should call this function to exit the fees they've collected for that particular block.
-The validator declares the block number, `blockNumber`, for which they'd like to exit fees, and the corresponding amount, `feeAmount`. This exit is then added to exit queue with the lowest priority for that block.
-Note that if the validator attempts to start an exit for a fee-UTXO that has already been spent in a later block, the exit can be challenged through `startTransactionExit` the same way as a regular transaction exit. However, if the fee-UTXO has not been spent, but the validator claims the incorrect `feeAmount` for a block, users should watch and exit.
+The validator declares the `blockNumber` of the block for which they'd like to exit fees. This exit is then added to exit queue with the lowest priority for that block.
+Note that if the validator attempts to start an exit for a fee-UTXO that has already been spent in a later block, the exit can be challenged through `startTransactionExit` the same way as a regular transaction exit.
 
 <br />
 

--- a/docs/rootchainFunctions.md
+++ b/docs/rootchainFunctions.md
@@ -2,12 +2,12 @@
 
 The transcation bytes, `txBytes`, in the contract follow the convention:  
 ```
-RLP_ENCODE ([ 
-  [Blknum1, TxIndex1, Oindex1, DepositNonce1, Amount1, ConfirmSig1,
+RLP_ENCODE ([
+  [Blknum1, TxIndex1, Oindex1, DepositNonce1, Owner1, Input1ConfirmSig,
 
-  Blknum2, TxIndex2, Oindex2, DepositNonce2, Amount2, ConfirmSig2,
+   Blknum2, TxIndex2, Oindex2, DepositNonce2, Owner2, Input2ConfirmSig,
 
-  NewOwner, Denom1, NewOwner, Denom2, Fee],
+   NewOwner, Denom1, NewOwner, Denom2, Fee],
 
   [Signature1, Signature2]
 ])

--- a/docs/rootchainFunctions.md
+++ b/docs/rootchainFunctions.md
@@ -65,6 +65,15 @@ This is because of the differing priority calculation. The priority of a deposit
 <br />
 
 ```solidity
+function startFeeExit(uint256 blockNumber, uint256 feeAmount)
+```
+The validator of any block should call this function to exit the fees they've collected for that particular block.
+The validator declares the block number, `blockNumber`, for which they'd like to exit fees, and the corresponding amount, `feeAmount`. This exit is then added to exit queue with the lowest priority for that block.
+Note that if the validator attempts to start an exit for a fee-UTXO that has already been spent in a later block, the exit can be challenged through `startTransactionExit` the same way as a regular transaction exit. However, if the fee-UTXO has not been spent, but the validator claims the incorrect `feeAmount` for a block, users should watch and exit.
+
+<br />
+
+```solidity
 function challengeTransactionExit(uint256[3] exitingTxPos, uint256[2] challengingTxPos, bytes txBytes, bytes proof, bytes confirmSignature)
 ```
 `exitingTxPos` and `challengingTxPos` follow the convention - `[blockNumber, transcationIndex, outputIndex]`

--- a/test/rootchain/blockSubmissions.js
+++ b/test/rootchain/blockSubmissions.js
@@ -14,11 +14,13 @@ contract('[RootChain] Block Submissions', async (accounts) => {
 
     it("Submit block from authority", async () => {
         let root = web3.sha3('1234');
-        let tx = await rootchain.submitBlock(root, [1], 1, {from: authority});
+        let tx = await rootchain.submitBlock(root, [1], [0], 1, {from: authority});
 
         // BlockSubmitted event
         assert.equal(tx.logs[0].args.root, root, "incorrect block root in BlockSubmitted event");
         assert.equal(tx.logs[0].args.blockNumber.toNumber(), 1, "incorrect block number in BlockSubmitted event");
+        assert.equal(tx.logs[0].args.numTxns.toNumber(), 1, "incorrect block size in BlockSubmitted event");
+        assert.equal(tx.logs[0].args.feeAmount.toNumber(), 0, "incorrect block fee amount in BlockSubmitted event");
 
         assert.equal((await rootchain.childChain.call(1))[0], root, 'Child block merkle root does not match submitted merkle root.');
     });
@@ -26,7 +28,7 @@ contract('[RootChain] Block Submissions', async (accounts) => {
     it("Submit block from someone other than authority", async () => {
         let prev = (await rootchain.lastCommittedBlock.call()).toNumber();
 
-        let [err] = await catchError(rootchain.submitBlock(web3.sha3('578484785954'), [1], 1, {from: accounts[1]}));
+        let [err] = await catchError(rootchain.submitBlock(web3.sha3('578484785954'), [1], [0], 1, {from: accounts[1]}));
         if (!err)
             assert.fail("Submitted blocked without being the authority");
 
@@ -40,20 +42,37 @@ contract('[RootChain] Block Submissions', async (accounts) => {
         let roots = root1 + root2;
 
         let lastCommitedBlock = 0;
-        await rootchain.submitBlock(toHex(roots), [1, 2], 1, {from: authority});
+        await rootchain.submitBlock(toHex(roots), [1, 2], [0, 0], 1, {from: authority});
 
         assert.equal((await rootchain.lastCommittedBlock.call()).toNumber(), 2, "blocknum incremented incorrectly");
         assert.equal((await rootchain.childChain.call(1))[0], toHex(root1), "mismatch in block root");
         assert.equal((await rootchain.childChain.call(2))[0], toHex(root2), "mismatch in block root");
     });
 
+    it("Can submit fees for a block", async () => {
+        let root1 = web3.sha3("root1").slice(2);
+        let root2 = web3.sha3("root2").slice(2);
+        let roots = root1 + root2;
+
+        let fees = [100, 200];
+
+        let lastCommitedBlock = 0;
+        await rootchain.submitBlock(toHex(roots), [1, 2], fees, 1, {from: authority});
+
+        assert.equal((await rootchain.lastCommittedBlock.call()).toNumber(), 2, "blocknum incremented incorrectly");
+        assert.equal((await rootchain.childChain.call(1))[0], toHex(root1), "mismatch in block root");
+        assert.equal((await rootchain.childChain.call(2))[0], toHex(root2), "mismatch in block root");
+        assert.equal((await rootchain.childChain.call(1))[2], fees[0], "mismatch in block fees");
+        assert.equal((await rootchain.childChain.call(2))[2], fees[1], "mismatch in block fees");
+    });
+
     it("Enforces block number ordering", async () => {
         let root1 = web3.sha3("root1").slice(2)
         let root3 = web3.sha3("root3").slice(2)
 
-        await rootchain.submitBlock(toHex(root1), [1], 1);
+        await rootchain.submitBlock(toHex(root1), [1], [0], 1);
         let err;
-        [err] = await catchError(rootchain.submitBlock(toHex(root3), [1], 3));
+        [err] = await catchError(rootchain.submitBlock(toHex(root3), [1], [0],3));
         if (!err)
             assert.fail("Allowed block submission with inconsistent ordering");
     });

--- a/test/rootchain/deposits.js
+++ b/test/rootchain/deposits.js
@@ -154,7 +154,7 @@ contract('[RootChain] Deposits', async (accounts) => {
         [root, proof] = generateMerkleRootAndProof([merkleHash], 0);
 
         let blockNum = (await rootchain.lastCommittedBlock.call()).toNumber() + 1;
-        await rootchain.submitBlock(toHex(root), [1], blockNum, {from: authority});
+        await rootchain.submitBlock(toHex(root), [1], [0], blockNum, {from: authority});
 
         // create the confirm sig
         let confirmHash = sha256String(merkleHash + root.slice(2));

--- a/test/rootchain/transactions.js
+++ b/test/rootchain/transactions.js
@@ -133,6 +133,10 @@ contract('[RootChain] Transactions', async (accounts) => {
         // check that the bond has been rewarded to the challenger
         let balance = (await rootchain.balanceOf.call(accounts[2])).toNumber();
         assert.equal(balance, minExitBond, "exit bond not rewarded to challenger");
+
+        let position = 1000000*txPos[0] + 10*txPos[1];
+        let exit = await rootchain.txExits.call(position);
+        assert.equal(exit[3].toNumber(), 2, "Fee exit state is not Challenged");
     });
 
     it("Catches StartedTransactionExit event", async () => {
@@ -306,6 +310,9 @@ contract('[RootChain] Transactions', async (accounts) => {
 
         let balance = (await rootchain.balanceOf.call(accounts[2])).toNumber();
         assert.equal(balance, minExitBond, "exit bond not rewarded to challenger");
+
+        feeExit = await rootchain.txExits.call(position);
+        assert.equal(feeExit[3].toNumber(), 2, "Fee exit state is not Challenged");
     });
 
     it("Requires sufficient bond and refunds excess if overpayed", async () => {
@@ -411,6 +418,10 @@ contract('[RootChain] Transactions', async (accounts) => {
 
         let balance = (await rootchain.balanceOf.call(accounts[2])).toNumber();
         assert.equal(balance, minExitBond, "exit bond not rewarded to challenger");
+
+        let position = 1000000*txPos[0];
+        let exit = await rootchain.txExits.call(position);
+        assert.equal(exit[3].toNumber(), 2, "Fee exit state is not Challenged");
 
         // start an exit of the new utxo after successfully challenging
         await rootchain.startTransactionExit([blockNum, 0, 0],

--- a/test/rootchain/transactions.js
+++ b/test/rootchain/transactions.js
@@ -177,6 +177,12 @@ contract('[RootChain] Transactions', async (accounts) => {
         if (!err)
             assert.fail("started fee exit with insufficient bond");
 
+        // cannot start a fee exit for a non-existent block
+        let nonExitentBlockNum = txPos[0] + 100;
+        [err] = await catchError(rootchain.startFeeExit(nonExitentBlockNum, feeAmount, {from: authority, value: minExitBond}));
+        if (!err)
+            assert.fail("started fee exit for non-existent block");
+
         // validator can start a fee exit with sufficient exit bond
         let tx = await rootchain.startFeeExit(txPos[0], feeAmount, {from: authority, value: minExitBond});
 
@@ -189,7 +195,7 @@ contract('[RootChain] Transactions', async (accounts) => {
         // can only start a fee exit for any particular block once
         [err] = await catchError(rootchain.startFeeExit(txPos[0], feeAmount, {from: authority, value: minExitBond}));
         if (!err)
-            assert.fail("reopened the same exit while already a pending one existed");
+            assert.fail("attempted the same exit while a pending one existed");
     });
 
     it("Allows validator to start and finalize a fee withdrawal exit", async () => {

--- a/test/rootchain/transactions.js
+++ b/test/rootchain/transactions.js
@@ -639,7 +639,7 @@ contract('[RootChain] Transactions', async (accounts) => {
         let merkleRoot2, proof2;
         [merkleRoot2, proof2] = generateMerkleRootAndProof([merkleHash2], 0);
         let blockNum2 = (await rootchain.lastCommittedBlock.call()).toNumber() + 1;
-        await rootchain.submitBlock(toHex(merkleRoot2), [1], blockNum2, {from: authority});
+        await rootchain.submitBlock(toHex(merkleRoot2), [1], [0], blockNum2, {from: authority});
 
         // construct the confirm signature
         let confirmHash2 = sha256String(merkleHash2 + merkleRoot2.slice(2));


### PR DESCRIPTION
Added `startFeeExit` method on the rootchain contract to allow a validator to claim a fee for a block.

Note that in the current implementation, if the validator attempts to exit a fee UTXO that has already been spent in a later block, the exit can be challenged through `startTransactionExit` the same way as a regular transaction exit. However, if the fee UTXO has not been spent, but the validator claims the incorrect fee amount for a block, users should watch and exit (there's no explicit check for the correct fee amount on the contract).
