### PR TITLE
Finalize Revert

### DIFF
--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -352,6 +352,10 @@ contract RootChain is Ownable {
     function finalizeDepositExits() public { finalize(depositExitQueue, true); }
     function finalizeTransactionExits() public { finalize(txExitQueue, false); }
 
+    // Finalizes exits by iterating through either the depositExitQueue or txExitQueue.
+    // Users can determine the number of exits they're willing to process by varying
+    // the amount of gas allow finalize*Exits() to process.
+    // Each transaction takes < 80000 wei to process.
     function finalize(uint256[] storage queue, bool isDeposits)
         private
     {
@@ -383,7 +387,8 @@ contract RootChain is Ownable {
         uint256 amountToAdd;
         while (queue.currentSize() > 0 &&
                (block.timestamp - currentExit.createdAt) > 1 weeks &&
-               currentExit.amount.add(minExitBond) <= address(this).balance - totalWithdrawBalance) {
+               currentExit.amount.add(minExitBond) <= address(this).balance - totalWithdrawBalance &&
+               msg.gas > 80000) {
 
             // skip currentExit if it is not in 'started/pending' state.
             if (currentExit.state != ExitState.Pending) {

--- a/contracts/rootchain/RootChain.sol
+++ b/contracts/rootchain/RootChain.sol
@@ -355,7 +355,7 @@ contract RootChain is Ownable {
     // Finalizes exits by iterating through either the depositExitQueue or txExitQueue.
     // Users can determine the number of exits they're willing to process by varying
     // the amount of gas allow finalize*Exits() to process.
-    // Each transaction takes < 80000 wei to process.
+    // Each transaction takes < 80000 gas to process.
     function finalize(uint256[] storage queue, bool isDeposits)
         private
     {

--- a/test/rootchain/transactions.js
+++ b/test/rootchain/transactions.js
@@ -1,3 +1,4 @@
+
 let RLP = require('rlp');
 let assert = require('chai').assert
 
@@ -456,11 +457,69 @@ contract('[RootChain] Transactions', async (accounts) => {
 
         // Fast Forward rest of challenge period
         fastForward(one_week);
-        await rootchain.finalizeTransactionExits({from: authority});
+        let tx = await rootchain.finalizeTransactionExits({from: authority});
         // Check that last exit was processed
         finalizedExit = await rootchain.txExits.call(position);
         assert.equal(finalizedExit[2], accounts[1], "Incorrect finalized exit owner");
         assert.equal(finalizedExit[0], 50, "Incorrect finalized exit amount");
         assert.equal(finalizedExit[3].toNumber(), 3, "Incorrect finalized exit state.");
+    });
+
+    it("Does not finalize a transaction exit if not enough gas", async () => {
+        depositNonce = (await rootchain.depositNonce.call()).toNumber();
+        await rootchain.deposit(accounts[0], {from: accounts[0], value: amount});
+
+        // deposit is the first input. accounts[0] sends entire deposit to accounts[1]
+        let txList2 = Array(17).fill(0);
+        txList2[3] = depositNonce; txList2[12] = accounts[1]; txList2[13] = amount;
+        let txHash2 = web3.sha3(RLP.encode(txList2).toString('hex'), {encoding: 'hex'});
+
+        let sigs2 = [toHex(await web3.eth.sign(accounts[0], txHash2)), toHex(Buffer.alloc(65).toString('hex'))];
+
+        txBytes2 = [txList2, sigs2];
+        txBytes2 = RLP.encode(txBytes2).toString('hex');
+
+        // submit the block
+        let merkleHash2 = sha256String(txBytes2);
+        let merkleRoot2, proof2;
+        [merkleRoot2, proof2] = generateMerkleRootAndProof([merkleHash2], 0);
+        let blockNum2 = (await rootchain.lastCommittedBlock.call()).toNumber() + 1;
+        await rootchain.submitBlock(toHex(merkleRoot2), [1], blockNum2, {from: authority});
+
+        // construct the confirm signature
+        let confirmHash2 = sha256String(merkleHash2 + merkleRoot2.slice(2));
+        confirmSignatures2 = await web3.eth.sign(accounts[0], confirmHash2);
+
+        txPos2 = [blockNum2, 0, 0];
+
+        // Start txn exit on both utxos
+        await rootchain.startTransactionExit(txPos,
+            toHex(txBytes), toHex(proof), toHex(confirmSignatures),
+            {from: accounts[1], value: minExitBond});
+
+        await rootchain.startTransactionExit(txPos2,
+            toHex(txBytes2), toHex(proof2), toHex(confirmSignatures2),
+            {from: accounts[1], value: minExitBond});
+
+        fastForward(one_week + 1000);
+
+        // Only provide enough gas for 1 txn to be finalized
+        await rootchain.finalizeTransactionExits({gas: 120000});
+
+        // The first utxo should have been exited correctly
+        let balance = (await rootchain.balanceOf.call(accounts[1])).toNumber();
+        assert.equal(balance, amount + minExitBond);
+
+        let position = 1000000*txPos[0];
+        let exit = await rootchain.txExits.call(position);
+        assert.equal(exit[3].toNumber(), 3, "exit's state not set to finalized");
+
+        // The second utxo exit should still be pending
+        balance = (await rootchain.balanceOf.call(accounts[1])).toNumber();
+        assert.equal(balance, amount + minExitBond);
+
+        position = 1000000*txPos2[0];
+        exit = await rootchain.txExits.call(position);
+        assert.equal(exit[3].toNumber(), 1, "exit has been challenged or finalized");
     });
 });

--- a/test/rootchain/transactions.js
+++ b/test/rootchain/transactions.js
@@ -1,4 +1,3 @@
-
 let RLP = require('rlp');
 let assert = require('chai').assert
 

--- a/test/rootchain/transactions.js
+++ b/test/rootchain/transactions.js
@@ -457,7 +457,7 @@ contract('[RootChain] Transactions', async (accounts) => {
 
         // Fast Forward rest of challenge period
         fastForward(one_week);
-        let tx = await rootchain.finalizeTransactionExits({from: authority});
+        await rootchain.finalizeTransactionExits({from: authority});
         // Check that last exit was processed
         finalizedExit = await rootchain.txExits.call(position);
         assert.equal(finalizedExit[2], accounts[1], "Incorrect finalized exit owner");


### PR DESCRIPTION
- Users can determine the number of exits they're willing to process by varying the amount of gas allow finalize*Exits() to process.
- Each transaction takes < 80000 gas to process.