### PR TITLE
Security Vulnerability Patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,9 +138,9 @@
       }
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "elliptic": ">=6.5.3",
     "ethereumjs-util": "^6.1.0",
     "rlp": "^2.2.2"
   },

--- a/test/plasmamvp/transactions.js
+++ b/test/plasmamvp/transactions.js
@@ -457,7 +457,7 @@ contract('[PlasmaMVP] Transactions', async (accounts) => {
         await fastForward(oneWeek + 1000);
 
         // Only provide enough gas for 1 txn to be finalized
-        await instance.finalizeTransactionExits({gas: 120000});
+        await instance.finalizeTransactionExits({gas: 150000});
 
         // The first utxo should have been exited correctly
         let balance = (await instance.balanceOf.call(authority)).toNumber();


### PR DESCRIPTION
I got the following github notification:
```
Remediation

Upgrade elliptic to version 6.5.3 or later. For example:

"dependencies": {
  "elliptic": ">=6.5.3"
}

or…

"devDependencies": {
  "elliptic": ">=6.5.3"
}


**Details**
CVE-2020-13822
high severity
Vulnerable versions: < 6.5.3
Patched version: 6.5.3

The Elliptic package before version 6.5.3 for Node.js allows ECDSA signature malleability via variations in encoding, leading '\0' bytes, or integer overflows. This could conceivably have a security-relevant impact if an application relied on a single canonical signature.
```

I bumped the version as specified in the alert. One of the tests failed because it required exact gas amount (which I guess has slight increases from the new version)

This should be cherry picked into a 1.1 security release. This should be fixed downstream in the sidechain as well by updating the contract to v1.1. 